### PR TITLE
[Sync UEFI-extraction with rbs/master] Temporary fix to z3-solver dependency issues (#401) 

### DIFF
--- a/disassemblers/ofrak_angr/CHANGELOG.md
+++ b/disassemblers/ofrak_angr/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased](https://github.com/redballoonsecurity/ofrak/tree/master)
 
+### Fixed
+- Add `importlib-resources` dependency as workaround for z3-solver dependency issue. ([#401](https://github.com/redballoonsecurity/ofrak/pull/401))
+
 ## 1.0.1 - 2023-06-26
 ### Fixed
 - Fix bug in THUMB mode handling of BasicBlocks and Instruction. ([#304](https://github.com/redballoonsecurity/ofrak/pull/304))

--- a/disassemblers/ofrak_angr/requirements.txt
+++ b/disassemblers/ofrak_angr/requirements.txt
@@ -1,1 +1,2 @@
 angr==9.2.6
+importlib-resources  # A workaround for https://github.com/redballoonsecurity/ofrak/issues/398

--- a/ofrak_core/setup.py
+++ b/ofrak_core/setup.py
@@ -54,7 +54,11 @@ setuptools.setup(
     + read_requirements("requirements.txt"),
     extras_require={
         "docs": read_requirements("requirements-docs.txt"),
-        "test": ["ofrak_angr~=1.0", "ofrak_capstone~=1.0"]
+        "test": [
+            "importlib-resources",  # Needed because of https://github.com/redballoonsecurity/ofrak/issues/398
+            "ofrak_angr~=1.0",
+            "ofrak_capstone~=1.0",
+        ]
         + read_requirements("requirements-test.txt"),
         "non-pypi": read_requirements("requirements-non-pypi.txt"),
     },


### PR DESCRIPTION
* Bump angr version to 9.2.82

* Add importlib-resources to depenenceis for ofrak-angr

* Remove angr bump

* Pin node Docker image

* Add ofrak-angr requirement

* Remove node pin

* Add importlib-resources as a test requirement for ofrak

* Revert change to node Docker image

* Update ofrak-angr changelog

---------

- [x] I have reviewed the [OFRAK contributor guide](https://ofrak.com/docs/contributor-guide/getting-started.html) and attest that this pull request is in accordance with it.

**One sentence summary of this PR (This should go in the CHANGELOG!)**

**Link to Related Issue(s)**

**Please describe the changes in your request.**

**Anyone you think should look at this, specifically?**
